### PR TITLE
Fix extraneous output in commit message helper

### DIFF
--- a/sbin/make_message.pl
+++ b/sbin/make_message.pl
@@ -67,8 +67,8 @@ open(GIT, $gitcommand);
 $rinamefiles = <GIT>;
 close(GIT);
 # Strip the "src/" (add to this list if needed)
+$rinamefiles =~ s/^\s+|\s+$//g if $rinamefiles;
 if ($rinamefiles) {
-print "$rinamefiles\n\n";
 $rinamefiles =~ s/  / /g;
 $rinamefiles =~ s/src\///g;
 $rinamefiles =~ s/interfaces\///g;


### PR DESCRIPTION
## Summary
- clean up `make_message.pl` to avoid printing raw `git status` output

## Testing
- `perl -c sbin/make_message.pl`


------
https://chatgpt.com/codex/tasks/task_e_68431a5a15408325a9ea576caf9a23d0